### PR TITLE
Changed supervisord.conf so that the correct home dir will be installed

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -12,5 +12,5 @@ command=chown -R jenkins:jenkins /var/lib/jenkins
 [program:jenkins]
 priority=30
 user=jenkins
-environment=JENKINS_HOME="/var/lib/jenkins"
+environment=JENKINS_HOME="/var/lib/jenkins",HOME="/var/lib/jenkins",USER="jenkins"
 command=java -jar /usr/share/jenkins/jenkins.war


### PR DESCRIPTION
Hi,
as discussed in: https://github.com/docker/docker/issues/14669
I changed the supervisor.conf so that the correct home dir will be used for jenkins.

Committer: Dennis Buerger dennis2me@googlemail.com
