### PR TITLE
Private registry certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,13 @@ RUN chmod +x /usr/local/bin/docker-compose
 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
+# copy files onto the filesystem
+COPY files/ /
+RUN chmod +x /docker-entrypoint /usr/local/bin/*
+
 EXPOSE 8080
+
+# set the entrypoint
+ENTRYPOINT ["/docker-entrypoint"]
 
 CMD ["/usr/bin/supervisord"]

--- a/files/docker-entrypoint
+++ b/files/docker-entrypoint
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# check to see if there are any registry certificates defined
+registry-certificate
+
+exec "$@"

--- a/files/usr/local/bin/registry-certificate
+++ b/files/usr/local/bin/registry-certificate
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ -n "${DOCKER_REGISTRY_CERT}" -a -e "${DOCKER_REGISTRY_CERT}" ]; then
+    cert_root=/etc/docker/certs.d/${DOCKER_REGISTRY_NAME}
+    mkdir -p ${cert_root}
+
+    cp ${DOCKER_REGISTRY_CERT} "${cert_root}/ca.crt"
+fi;


### PR DESCRIPTION
Provides the ability to pass in a registry certificate so that Docker inside the container can push to a private registry with a self-signed certificate.
